### PR TITLE
Add Codable conformances to the OSC value types

### DIFF
--- a/Sources/CoreOSC/OSCAddressPattern.swift
+++ b/Sources/CoreOSC/OSCAddressPattern.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// An object that represents the full path to one or more OSC Methods through pattern matching.
-public struct OSCAddressPattern: Hashable, Equatable, Sendable {
+public struct OSCAddressPattern: Hashable, Equatable, Sendable, Codable {
     
     /// The full path to one or more OSC Methods.
     public let fullPath: String

--- a/Sources/CoreOSC/OSCArgument.swift
+++ b/Sources/CoreOSC/OSCArgument.swift
@@ -38,7 +38,7 @@ public protocol OSCArgumentProtocol: Sendable {
     
 }
 
-public enum OSCArgument: OSCArgumentProtocol, CustomStringConvertible, Equatable {
+public enum OSCArgument: OSCArgumentProtocol, CustomStringConvertible, Equatable, Codable {
 
     case int32(Int32)
     case float32(Float32)

--- a/Sources/CoreOSC/OSCBundle.swift
+++ b/Sources/CoreOSC/OSCBundle.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// An OSC Bundle.
-public struct OSCBundle: Sendable, Equatable {
+public struct OSCBundle: Sendable, Equatable, Codable {
 
     /// The bundles time tag used to indicate
     ///when it's contained elements should be invoked

--- a/Sources/CoreOSC/OSCMessage.swift
+++ b/Sources/CoreOSC/OSCMessage.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// An OSC Message.
-public struct OSCMessage: Sendable, Equatable {
+public struct OSCMessage: Sendable, Equatable, Codable {
 
     public static func == (lhs: OSCMessage, rhs: OSCMessage) -> Bool {
         lhs.addressPattern == rhs.addressPattern &&

--- a/Sources/CoreOSC/OSCPacket.swift
+++ b/Sources/CoreOSC/OSCPacket.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// An OSC Packet, either an `OSCMessage` or `OSCBundle`.
-@frozen public enum OSCPacket: Sendable, Equatable {
+@frozen public enum OSCPacket: Sendable, Equatable, Codable {
     /// An OSC Message.
     case message(OSCMessage)
     /// An OSC Bundle.

--- a/Sources/CoreOSC/OSCTimeTag.swift
+++ b/Sources/CoreOSC/OSCTimeTag.swift
@@ -24,7 +24,7 @@
 import Foundation
 
 /// An OSC Time Tag.
-public struct OSCTimeTag: OSCArgumentProtocol, Equatable, CustomStringConvertible, Sendable {
+public struct OSCTimeTag: OSCArgumentProtocol, Equatable, CustomStringConvertible, Sendable, Codable {
 
     /// The OSC data representation for the argument.
     public var oscData: Data { Data(seconds.bigEndian.data + fraction.bigEndian.data) }

--- a/Tests/CoreOSCTests/OSCCodableTests.swift
+++ b/Tests/CoreOSCTests/OSCCodableTests.swift
@@ -1,0 +1,95 @@
+//
+//  OSCCodableTests.swift
+//  CoreOSCTests
+//
+//  Created by Sam Smallman on 14/06/2026.
+//  Copyright © 2026 Sam Smallman. https://github.com/SammySmallman
+//
+//  This file is part of CoreOSC
+//
+//  CoreOSC is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU Affero General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  CoreOSC is distributed in the hope that it will be useful
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Affero General Public License for more details.
+//
+//  You should have received a copy of the GNU Affero General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import CoreOSC
+
+/// Verifies the synthesised `Codable` conformances round-trip every OSC type
+/// through `JSONEncoder`/`JSONDecoder` without loss.
+final class OSCCodableTests: XCTestCase {
+
+    private func assertRoundTrip<Value: Codable & Equatable>(
+        _ value: Value,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let data = try JSONEncoder().encode(value)
+        let decoded = try JSONDecoder().decode(Value.self, from: data)
+        XCTAssertEqual(value, decoded, file: file, line: line)
+    }
+
+    func testOSCArgumentRoundTrips() throws {
+        try assertRoundTrip(OSCArgument.int32(42))
+        try assertRoundTrip(OSCArgument.float32(3.142))
+        try assertRoundTrip(OSCArgument.string("Core OSC"))
+        try assertRoundTrip(OSCArgument.blob(Data([0x01, 0x02, 0x03])))
+        try assertRoundTrip(OSCArgument.true)
+        try assertRoundTrip(OSCArgument.false)
+        try assertRoundTrip(OSCArgument.nil)
+        try assertRoundTrip(OSCArgument.impulse)
+        try assertRoundTrip(OSCArgument.timeTag(.immediate))
+    }
+
+    func testOSCTimeTagRoundTrips() throws {
+        try assertRoundTrip(OSCTimeTag.immediate)
+        try assertRoundTrip(OSCTimeTag(date: Date(timeIntervalSince1970: 1_700_000_000)))
+    }
+
+    func testOSCAddressPatternRoundTrips() throws {
+        try assertRoundTrip(try OSCAddressPattern("/core/osc/1"))
+        try assertRoundTrip(OSCAddressPattern(raw: "/core/osc/*"))
+    }
+
+    func testOSCMessageRoundTrips() throws {
+        let message = OSCMessage(
+            raw: "/core/osc",
+            arguments: [
+                .int32(1),
+                .float32(3.142),
+                .string("Core OSC"),
+                .timeTag(.immediate),
+                .true,
+                .false,
+                .blob(Data([0x01, 0x01])),
+                .nil,
+                .impulse
+            ]
+        )
+        try assertRoundTrip(message)
+    }
+
+    func testOSCBundleAndPacketRoundTrip() throws {
+        let bundle = OSCBundle(
+            [
+                .message(OSCMessage(raw: "/core/osc/1", arguments: [.int32(1)])),
+                .bundle(OSCBundle([
+                    .message(OSCMessage(raw: "/core/osc/2", arguments: [.string("nested")]))
+                ]))
+            ],
+            timeTag: .immediate
+        )
+        try assertRoundTrip(bundle)
+        try assertRoundTrip(OSCPacket.bundle(bundle))
+        try assertRoundTrip(OSCPacket.message(OSCMessage(raw: "/core/osc", arguments: [.true])))
+    }
+}


### PR DESCRIPTION
## Summary

- Conform `OSCArgument`, `OSCMessage`, `OSCAddressPattern`, `OSCTimeTag`, `OSCPacket` and `OSCBundle` to `Codable`.
- All conformances are Swift's synthesised ones — no hand-written codecs — so they stay correct as the types evolve.
- Enables OSC values to be serialised: carried across an XPC boundary, persisted to disk, or otherwise encoded/decoded.

## Test plan

- Added `OSCCodableTests` with JSON round-trip assertions for every type and all nine argument cases (including nested bundles).
- `swift test` — 104 tests pass.