### PR TITLE
Migrate to Swift 6 language mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
## Summary
- Bumps `swift-tools-version` to 6.0
- No source changes needed — the package already builds clean under strict concurrency checking